### PR TITLE
Feature/cloud 1090 add quality wait

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,8 +18,9 @@ jobs:
           fetch-depth: 0
 
       - name: Lint Code Base
-        uses: github/super-linter@v3
+        uses: github/super-linter@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_DOCKERFILE: false
+          VALIDATE_GITHUB_ACTIONS: false

--- a/action.yml
+++ b/action.yml
@@ -18,4 +18,4 @@ inputs:
     default: "pytest"
 runs:
   using: "docker"
-  image: docker://public.ecr.aws/p4v7w0a5/lazy/python-action:v1.1.0
+  image: docker://public.ecr.aws/p4v7w0a5/lazy/python-action:v1.2.0

--- a/scripts/coverage_scan.sh
+++ b/scripts/coverage_scan.sh
@@ -37,10 +37,16 @@ export PULL_REQUEST_KEY=$pull_number
 
 echo "------Sonar tests."
 
+wait_flag="false"
+if [ "$BRANCH_NAME" == "master" ] || [ "$BRANCH_NAME" == "main" ]; then
+  wait_flag="true"
+fi
+
 sonar_args="-Dsonar.host.url=https://sonarcloud.io \
             -Dsonar.login=$SONAR_TOKEN \
             -Dsonar.scm.revision=$GITHUB_SHA \
-            -Dsonar.python.coverage.reportPaths=coverage.xml"
+            -Dsonar.python.coverage.reportPaths=coverage.xml \
+            -Dsonar.qualitygate.wait=$wait_flag"
 
 if [ "$PULL_REQUEST_KEY" = null ]; then
   echo "Sonar run when pull request key is null."


### PR DESCRIPTION
# Description

Add qualitygate.wait flag to sonar scan if on master branch.

Note: Left check for test branch. Will remove that check after testing is complete. Will also change image tag back after approval.

Fixes [#1090](https://usxtech.atlassian.net/browse/CLOUD-1090)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Test Cases:
```yaml
- Fail on master:
  - Steps: Commit a dummy commit to lazy api test/CLOUD-1090-test-sonar, leaving dummy function in.
  - Expected: Sonar quality gate fails, failing the build. No trivy scan is done.
  - Actual: [PASSED] Sonar fails:  https://github.com/variant-inc/lazy-api/runs/4958642692?check_suite_focus=true#step:6:1037
- Pass on master:
  - Steps: Commit a dummy commit to lazy api test/CLOUD-1090-test-sonar, removing dummy function in.
  - Expected: Sonar quality gate passes, build continues on to trivy scan. (May fail on trivy scan)
  - Actual: [PASSED] Sonar passes: https://github.com/variant-inc/lazy-api/actions/runs/1753322873
- Fail on feature:
  - Create a new test branch with a different name in lazy-api. Make sure actions-python step points to this branch. Add a dummy function with at least 20 lines and no unit tests.
  - Expected: Sonar quality gate fails, but build continues on to trivy scan. (May fail on trivy scan)
  - Actual: [FAILED] Sonar Passes: https://github.com/variant-inc/lazy-api/actions/runs/1753438922 
  - Maybe I did something wrong with the dummy function?
- Pass on feature:
  - Create a new test branch with a different name in lazy-api. Make sure actions-python step points to this branch. Create a dummy commit.
  - Expected: Sonar quality gate passes, build continues on to trivy scan. )May fail on trivy scan)
  - Actual: [PASS] Sonar Passes https://github.com/variant-inc/lazy-api/actions/runs/1753399912 

Tested by adding dummy function to the branch, works as expected (Naveen)

```
*Note for testing. Lazy-api branch "test/CLOUD-1090-test-sonar will be used to simulate master branch scenarios.

- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added documentation to test
