### PR TITLE
fix: token write for actions-setup and release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
   Release:
     permissions:
       contents: write
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - uses: variant-inc/actions-setup@v2


### PR DESCRIPTION
# Description

Fix for git version and usage of actions-setup
[CLOUD-2618](https://usxpress.atlassian.net/browse/CLOUD-2618)

This is needed as now we're using actions-setup to run GitVersion and actions-setup has configure AWS credentials action which needs token permission to authenticate [source](https://github.com/aws-actions/configure-aws-credentials?tab=readme-ov-file#oidc).
https://github.com/variant-inc/actions-setup/blob/master/action.yml#L32

## Type of change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

```text
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
```

- [ ] Sanity Testing

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added documentation to test


[CLOUD-2618]: https://usxpress.atlassian.net/browse/CLOUD-2618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ